### PR TITLE
Allow zodbsync module.

### DIFF
--- a/Products/ZPerFactMods/allowScriptModules.py
+++ b/Products/ZPerFactMods/allowScriptModules.py
@@ -67,6 +67,7 @@ allow_module("perfact.webservice")
 allow_module("perfact.winvnc")
 allow_module("perfact.xls")
 allow_module("perfact.zopeinterface")
+allow_module("perfact.zodbsync")
 
 # This is on by default in Zope2, but not in Zope4
 allow_module("Products.PythonScripts.standard")


### PR DESCRIPTION
This will be needed for several features required for Zope 4 (obtaining the modtime of an object, replacing the External Editor)