### PR TITLE
Allow module ZTUtils

### DIFF
--- a/Products/ZPerFactMods/allowScriptModules.py
+++ b/Products/ZPerFactMods/allowScriptModules.py
@@ -24,6 +24,9 @@ allow_module("datetime")
 # Allow the time module
 allow_module("time")
 
+# Allow ZTUtils, it provides url_query which is used in db_edit_magnetic
+allow_module("ZTUtils")
+
 # Allow access to python module "perfact" and submodules
 allow_module("perfact.LDAP")
 allow_module("perfact.asterisk_utils")


### PR DESCRIPTION
In Zope 2, `ZTUtils` was somehow implicitly allowed (or we had a package installed that allowed it, not sure), in Zope 4.1 it no longer is. It is used in various places to provide `url_query()`