### PR TITLE
Weaken dependency on python-perfact.

### DIFF
--- a/Products/ZPerFactMods/ZServer_hideversion.py
+++ b/Products/ZPerFactMods/ZServer_hideversion.py
@@ -2,5 +2,10 @@
 # Change behavior of ZServer so it does not tell the client which server version is running
 #
 
-import ZServer
-ZServer.zhttp_server.SERVER_IDENT = ''
+# On Zope4/Python3, there is no ZServer.
+# TODO: WSGI equivalent
+try:
+    import ZServer
+    ZServer.zhttp_server.SERVER_IDENT = ''
+except ImportError:
+    pass

--- a/Products/ZPerFactMods/allowScriptModules.py
+++ b/Products/ZPerFactMods/allowScriptModules.py
@@ -77,11 +77,20 @@ allow_module("Products.PythonScripts.standard")
 
 # In order to use the central connector, we need to allow access to
 # the class.
-from perfact.dbconn import DBConn
-allow_class(DBConn)
+try:
+    from perfact.dbconn import DBConn
+    allow_class(DBConn)
+except ImportError:
+    pass
 
-from perfact.latex import HTML2Tex
-allow_class(HTML2Tex)
+try:
+    from perfact.latex import HTML2Tex
+    allow_class(HTML2Tex)
+except ImportError:
+    pass
 
-from perfact.network import InterfacesParser
-allow_class(InterfacesParser)
+try:
+    from perfact.network import InterfacesParser
+    allow_class(InterfacesParser)
+except ImportError:
+    pass

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '0.1'
+version = '3.13.0'
 
 setup(name='Products.ZPerFactMods',
       version=version,


### PR DESCRIPTION
In order to make these packages more independent, `allowScriptModules` will
no longer fail if `python-perfact` is not installed (although it will not
do much, either).
Also, `ZServer_hideversion` will no longer break if no `ZServer` is present,
e.g. in Python3/Zope4 with WSGI.
Finally, increase the version in order to allow `perfact-dbutils-zope2` to
reference a specific version from now on.