### PR TITLE
Allow import for sql_quoting

### DIFF
--- a/Products/ZPerFactMods/allowScriptModules.py
+++ b/Products/ZPerFactMods/allowScriptModules.py
@@ -75,6 +75,8 @@ allow_module("perfact.zodbsync")
 # This is on by default in Zope2, but not in Zope4
 allow_module("Products.PythonScripts.standard")
 
+allow_module("DocumentTemplate.DT_Var")
+
 # In order to use the central connector, we need to allow access to
 # the class.
 try:

--- a/Products/ZPerFactMods/allowScriptModules.py
+++ b/Products/ZPerFactMods/allowScriptModules.py
@@ -75,6 +75,7 @@ allow_module("perfact.zodbsync")
 # This is on by default in Zope2, but not in Zope4
 allow_module("Products.PythonScripts.standard")
 
+# Needed for sql_quote()
 allow_module("DocumentTemplate.DT_Var")
 
 # In order to use the central connector, we need to allow access to

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '3.13.0'
+version = '3.14.0'
 
 setup(name='Products.ZPerFactMods',
       version=version,


### PR DESCRIPTION
We need to import DocumentTemplate.DT_Var to use the better sql_quoting.