### PR TITLE
T294880 Consider allowedclasses hook in perfact packages

### DIFF
--- a/Products/ZPerFactMods/allowScriptModules.py
+++ b/Products/ZPerFactMods/allowScriptModules.py
@@ -54,8 +54,7 @@ for module in pkgutil.walk_packages(perfact.__path__, f"{perfact.__name__}."):
 
     try:
         allowed_mod = importlib.import_module(allowed_mod_name)
-    except ImportError:
-        # we dont have an allowedclasses module. Skip
+    except Exception:
         continue
 
     if not hasattr(allowed_mod, "__all__"):
@@ -96,15 +95,5 @@ except ImportError:
 try:
     from perfact.network import InterfacesParser
     allow_class(InterfacesParser)
-except ImportError:
-    pass
-
-try:
-    from perfact.dbutils.conn import ZRDBConnectionWrapper
-    from perfact.dbutils.conn import Namespace
-    from perfact.dbutils.conn import Results
-    allow_class(ZRDBConnectionWrapper)
-    allow_class(Namespace)
-    allow_class(Results)
 except ImportError:
     pass

--- a/Products/ZPerFactMods/allowScriptModules.py
+++ b/Products/ZPerFactMods/allowScriptModules.py
@@ -34,24 +34,11 @@ allow_module("ZTUtils")
 # Allow access to python module "perfact" and submodules, recursively
 # but skip modules in perfact.tests
 for module in pkgutil.walk_packages(perfact.__path__, f'{perfact.__name__}.'):
+    # Allow perfact modules except test modules
     if '.tests' not in module.name:
         allow_module(module.name)
-
-# This is on by default in Zope2, but not in Zope4
-allow_module("Products.PythonScripts.standard")
-
-# Needed for sql_quote()
-allow_module("DocumentTemplate.DT_Var")
-
-# Allow the cbor2-decoder module
-allow_module("cbor2.decoder")
-
-for module in pkgutil.walk_packages(perfact.__path__, f"{perfact.__name__}."):
-    if ".tests" in module.name:
-        continue
-
+    # Check if our package has an allowedclasses module by trying to import it
     allowed_mod_name = f"{module.name}.allowedclasses"
-
     try:
         allowed_mod = importlib.import_module(allowed_mod_name)
     except Exception:
@@ -62,21 +49,26 @@ for module in pkgutil.walk_packages(perfact.__path__, f"{perfact.__name__}."):
             f"{allowed_mod_name} must define __all__"
         )
 
+    # Get names of the allowed classes
     names = allowed_mod.__all__
     objects = (getattr(allowed_mod, name, None) for name in names)
-
+    # Try to allow all given classes
     for obj in objects:
         if obj is None:
             continue
-
-        # Security check. Check if class is really from perfact package
-        if not obj.__module__.startswith(perfact.__name__):
-            continue
-
         try:
             allow_class(obj)
         except Exception:
             pass
+
+# This is on by default in Zope2, but not in Zope4
+allow_module("Products.PythonScripts.standard")
+
+# Needed for sql_quote()
+allow_module("DocumentTemplate.DT_Var")
+
+# Allow the cbor2-decoder module
+allow_module("cbor2.decoder")
 
 # In order to use the central connector, we need to allow access to
 # the class.

--- a/Products/ZPerFactMods/allowScriptModules.py
+++ b/Products/ZPerFactMods/allowScriptModules.py
@@ -3,6 +3,8 @@ import perfact
 from Products.PythonScripts.Utility import allow_module, allow_class
 from AccessControl import ModuleSecurityInfo, ClassSecurityInfo
 from AccessControl.class_init import InitializeClass
+import importlib
+
 
 # Allowing whole modules
 # allow_module("module_name").
@@ -43,6 +45,39 @@ allow_module("DocumentTemplate.DT_Var")
 
 # Allow the cbor2-decoder module
 allow_module("cbor2.decoder")
+
+for module in pkgutil.walk_packages(perfact.__path__, f"{perfact.__name__}."):
+    if ".tests" in module.name:
+        continue
+
+    allowed_mod_name = f"{module.name}.allowedclasses"
+
+    try:
+        allowed_mod = importlib.import_module(allowed_mod_name)
+    except ImportError:
+        # we dont have an allowedclasses module. Skip
+        continue
+
+    if not hasattr(allowed_mod, "__all__"):
+        raise RuntimeError(
+            f"{allowed_mod_name} must define __all__"
+        )
+
+    names = allowed_mod.__all__
+    objects = (getattr(allowed_mod, name, None) for name in names)
+
+    for obj in objects:
+        if obj is None:
+            continue
+
+        # Security check. Check if class is really from perfact package
+        if not obj.__module__.startswith(perfact.__name__):
+            continue
+
+        try:
+            allow_class(obj)
+        except Exception:
+            pass
 
 # In order to use the central connector, we need to allow access to
 # the class.

--- a/Products/ZPerFactMods/allowScriptModules.py
+++ b/Products/ZPerFactMods/allowScriptModules.py
@@ -89,3 +89,13 @@ try:
     allow_class(InterfacesParser)
 except ImportError:
     pass
+
+try:
+    from perfact.dbutils.conn import ZRDBConnectionWrapper
+    from perfact.dbutils.conn import Namespace
+    from perfact.dbutils.conn import Results
+    allow_class(ZRDBConnectionWrapper)
+    allow_class(Namespace)
+    allow_class(Results)
+except ImportError:
+    pass

--- a/Products/ZPerFactMods/allowScriptModules.py
+++ b/Products/ZPerFactMods/allowScriptModules.py
@@ -35,8 +35,9 @@ allow_module("ZTUtils")
 # but skip modules in perfact.tests
 for module in pkgutil.walk_packages(perfact.__path__, f'{perfact.__name__}.'):
     # Allow perfact modules except test modules
-    if '.tests' not in module.name:
-        allow_module(module.name)
+    if '.tests' in module.name:
+        continue
+    allow_module(module.name)
     # Check if our package has an allowedclasses module by trying to import it
     allowed_mod_name = f"{module.name}.allowedclasses"
     try:


### PR DESCRIPTION
Check if the allowed perfact packages have a module named allowedclasses. If the allowedclasses exists, allow all classes mentioned in __all__