### PR TITLE
Rely on walk_packages to determine existence of allowedclasses module

### DIFF
--- a/Products/ZPerFactMods/allowScriptModules.py
+++ b/Products/ZPerFactMods/allowScriptModules.py
@@ -37,22 +37,21 @@ for module in pkgutil.walk_packages(perfact.__path__, f'{perfact.__name__}.'):
     # Allow perfact modules except test modules
     if '.tests' in module.name:
         continue
-    allow_module(module.name)
-    # Check if our package has an allowedclasses module by trying to import it
-    allowed_mod_name = f"{module.name}.allowedclasses"
-    try:
-        allowed_mod = importlib.import_module(allowed_mod_name)
-    except Exception:
+
+    if not module.name.endswith('.allowedclasses'):
+        allow_module(module.name)
         continue
 
-    if not hasattr(allowed_mod, "__all__"):
+    # Special handling for allowedclasses module
+    mod = importlib.import_module(module.name)
+    if not hasattr(mod, "__all__"):
         raise RuntimeError(
-            f"{allowed_mod_name} must define __all__"
+            f"{module.name} must define __all__"
         )
 
     # Get names of the allowed classes
-    names = allowed_mod.__all__
-    objects = (getattr(allowed_mod, name, None) for name in names)
+    names = mod.__all__
+    objects = (getattr(mod, name, None) for name in names)
     # Try to allow all given classes
     for obj in objects:
         if obj is None:


### PR DESCRIPTION
The used function pkgutil.walk_packages is already able to determine whether we have an "allowedclasses" module, so "importing" everything to check for this is not necessary and can also cause issues when imported modules execute code like `__main__` modules 